### PR TITLE
Add generator

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/decidim/decidim
-  revision: ced72e3aac3fe7d7405b801816eff3ad6b8b44ef
+  revision: 6647a17f473542f7c3320a8fd33e4986ecfe1c61
   branch: master
   specs:
     decidim (0.10.0.pre)
@@ -139,7 +139,7 @@ GIT
 
 GIT
   remote: https://github.com/podemos-info/decidim-module-census_connector
-  revision: 18eac23bd28c8f4269a180b4d9c1c607b2bcd5ca
+  revision: 74c83cf4b1c5a675c55e64b18801721102cf120f
   branch: master
   specs:
     decidim-census_connector (0.10.0.pre)
@@ -414,8 +414,8 @@ GEM
       activerecord (>= 4.2, < 5.2)
       request_store (~> 1.1)
     parallel (1.12.1)
-    parser (2.4.0.2)
-      ast (~> 2.3)
+    parser (2.5.0.0)
+      ast (~> 2.4.0)
     pg (0.21.0)
     polyamorous (1.3.3)
       activerecord (>= 3.0)

--- a/README.md
+++ b/README.md
@@ -29,7 +29,11 @@ And then execute:
 bundle
 bundle exec rails decidim_collaborations:install:migrations
 bundle exec rails db:migrate
+bundle exec rails generate decidim:collaborations:install
 ```
+
+Then you'll need to configure the environment variable CENSUS_URL to point to
+the running instance of [census].
 
 ## Tests
 
@@ -93,3 +97,5 @@ executed.
 ## License
 
 This engine is distributed under the GNU AFFERO GENERAL PUBLIC LICENSE.
+
+[census]: https://github.com/podemos-info/census

--- a/Rakefile
+++ b/Rakefile
@@ -6,4 +6,6 @@ desc "Generates a dummy app for testing"
 task test_app: "decidim:generate_external_test_app"
 
 desc "Generates a development app."
-task development_app: "decidim:generate_external_development_app"
+task development_app: "decidim:generate_external_development_app" do
+  sh("bin/rails generate decidim:collaborations:install")
+end

--- a/lib/generators/decidim/collaborations/install/install_generator.rb
+++ b/lib/generators/decidim/collaborations/install/install_generator.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Collaborations
+    module Generators
+      class InstallGenerator < ::Rails::Generators::Base
+        desc <<~DESC
+          Description:
+            Install crowdfundings module into a decidim application.
+        DESC
+
+        def install_census_connector
+          invoke "decidim:census_connector:install"
+        end
+
+        def enhance_decidim_controller
+          inject_into_file "app/controllers/decidim_controller.rb",
+                           after: "class DecidimController < ApplicationController\n" do
+            <<~RUBY.gsub(/^ *\|/, "")
+              |  include Decidim::CensusConnector::CensusContext
+
+              |  helper Decidim::Collaborations::CollaborationsHelper
+              |  helper Decidim::Collaborations::TotalsHelper
+            RUBY
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

I'm adding a generator to the gem so it can be easily configured by end users against their application. Depends on https://github.com/podemos-info/decidim-module-census_connector/pull/8 that does the same thing for `decidim-census_connector`.

#### :pushpin: Related Issues
_None_.

#### :clipboard: Subtasks
_None_.

### :camera: Screenshots (optional)
_None_.

#### :ghost: GIF
_None_.